### PR TITLE
Declare the version the page is about in the custom example

### DIFF
--- a/docs/api/pricing-description-languages/Pricing2Yaml/versions/pricing2yaml-v31-specification.mdx
+++ b/docs/api/pricing-description-languages/Pricing2Yaml/versions/pricing2yaml-v31-specification.mdx
@@ -61,7 +61,7 @@ import PlansPrivate from "./v2.0/_plans_private.mdx";
 import AddOnsPrivate from "./v2.0/_addons_private.mdx";
 import Version from "./v2.1/_version.mdx";
 import SyntaxVersion from "./v3.1/_syntax_version_31.mdx";
-import Custom from "./v3.0/_custom.mdx";
+import Custom from "./v3.1/_custom.mdx";
 
 # Version 3.1
 

--- a/docs/api/pricing-description-languages/Pricing2Yaml/versions/v3.1/_custom.mdx
+++ b/docs/api/pricing-description-languages/Pricing2Yaml/versions/v3.1/_custom.mdx
@@ -40,7 +40,7 @@ Responsibility for interpreting and validating the contents of the custom field 
 
 ```yaml
 saasName: "ExampleSaaS"
-syntaxVersion: "3.0"
+syntaxVersion: "3.1"
 ...
 custom:
   deployment:


### PR DESCRIPTION
## Context

While integrating an asyncio gateway against SPACE I read the Pricing2Yaml 3.1 page and wrote `syntaxVersion: "3.0"` into our pricing, because that is what the page said. I flagged it on [isa-group/space#58](https://github.com/isa-group/space/pull/58), and it is already fixed here by 107c545 — the v3.1 page now has its own `_syntax_version_31.mdx` instead of importing the 3.0 partial. Thank you.

This PR is the same class of error, one field further down, and it is still present on `develop`.

## The problem

`versions/v3.0/_custom.mdx` is imported by **both** specification pages:

```
pricing2yaml-v30-specification.mdx:64: import Custom from "./v3.0/_custom.mdx";
pricing2yaml-v31-specification.mdx:64: import Custom from "./v3.0/_custom.mdx";
```

and its example hard-codes one version:

```yaml
saasName: "ExampleSaaS"
syntaxVersion: "3.1"
...
custom:
  deployment:
    region: "us-east-1"
```

So a reader on the **Version 3.0** page, at `## custom`, is shown a snippet declaring `syntaxVersion: "3.1"`. `custom` is a documented field of 3.0 — the v3.0 page has its own `## custom` section — so the field belongs on both pages; only the version number in the example is wrong for one of them.

This is the failure mode the `syntaxVersion` fix just addressed: a partial that is correct for the version it lives under, reused by a page about a different version. It is easy to trust, because the surrounding page is about 3.0 and nothing signals that one line of the example is not.

## The change

Split the partial per version, the way `syntaxVersion` already is:

- `v3.0/_custom.mdx` — example now declares `syntaxVersion: "3.0"`.
- `v3.1/_custom.mdx` — new, identical but declaring `"3.1"`.
- `pricing2yaml-v31-specification.mdx` imports the 3.1 partial.

Nothing else changes: same prose, same warning admonition, same `VersionTable`.

## Verification

`pnpm build` succeeds, and the rendered HTML of each page carries the right number under `## custom`:

```
build/.../pricing2yaml-v30-specification/index.html   ExampleSaaS" syntaxVersion: "3.0" ... custom:
build/.../pricing2yaml-v31-specification/index.html   ExampleSaaS" syntaxVersion: "3.1" ... custom:
```

I also swept the rest of the Pricing2Yaml version partials for the same pattern — an example hard-coding a `syntaxVersion` inside a partial shared across version pages — and `_custom.mdx` is the only remaining one. The other partials the 3.1 page imports from `v3.0/` (`_usage_limits_type`, `_usageLimits_period`, `_usageLimits_trackable`, `_addons_subscriptionConstraints`) carry no version-specific value, so sharing them is correct.

## Scope

Three files, one of them a copy. No prose rewritten and no change to what either version of the language actually specifies.
